### PR TITLE
Revert to InjectionManager for Atomicity

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -21,13 +21,11 @@ async def main():
     await init_db()
 
     # Load the replay
-    replay = sc2reader.load_replay("examples/example_5.SC2Replay")
+    replay = sc2reader.load_replay("examples/example_5.SC2Replay", load_level=4, load_map=True)
 
     # Create the InjectionManager and inject the replay
     print("Injecting replay data...")
-    ## manager = InjectionManager(Base)
-    manager = EventInjectionManager(Base)
-
+    manager = InjectionManager(Base)
     async with SessionLocal() as session:
         await manager.inject(replay, session)
 

--- a/database/inject/InjectionManager.py
+++ b/database/inject/InjectionManager.py
@@ -33,72 +33,6 @@ class InjectionManager():
             print(f"Unexpected error: {e}")
             # Gracefully handle all other exceptions
 
-class EventInjectionManager:
-    def __init__(self, base):
-        """
-        Initialize the EventInjectionManager.
-        :param base: SQLAlchemy Base, providing metadata and injectable models.
-        """
-        self.base = base
-        self.metadata = base.metadata
-        self.events = {}  # Dictionary to track events for each table
-
-    def _get_event(self, table_name):
-        """
-        Retrieve or create an asyncio.Event for a specific table.
-        :param table_name: Fully qualified table name (e.g., schema.table).
-        :return: asyncio.Event instance.
-        """
-        if table_name not in self.events:
-            self.events[table_name] = Event()
-        return self.events[table_name]
-
-    async def inject(self, replay, session):
-        """
-        Perform the injection process using Event-based synchronization.
-        :param replay: Parsed replay object to inject.
-        :param session: Database session supporting flush, commit, and rollback.
-        """
-        tasks = []
-        for name, relation in self.metadata.tables.items():
-            relation_cls = self.base.injectable.get(name)
-
-            if relation_cls and issubclass(relation_cls, Injectable):
-                # Define dependencies from the class relationships
-                dependencies = []
-                for dependency in relation.foreign_key_constraints:
-                    fkey = f"{dependency.referred_table.schema}.{dependency.referred_table.name}"
-                    dependencies.append(fkey)
-
-                # Inject the current relation
-                tasks.append(self._inject_relation(relation_cls, replay, session, dependencies))
-
-        # Run all tasks concurrently
-        await gather(*tasks)
-        await session.commit()
-
-    async def _inject_relation(self, relation_cls, replay, session, dependencies):
-        """
-        Inject a single relation, waiting for dependencies to complete.
-        :param relation_cls: The model class to process.
-        :param replay: Parsed replay object.
-        :param session: Database session.
-        :param dependencies: List of dependent table names.
-        """
-        for dep in dependencies:
-            await self._get_event(dep).wait()  # Wait for dependencies to complete
-
-        try:
-            # Process the current relation
-            await relation_cls.process(replay, session)
-            await session.flush()  # Flush after processing
-        except Exception as e:
-            await session.rollback()
-            print(f"Error processing {relation_cls.__tablename__}: {e}")
-        finally:
-            # Signal that this relation is complete
-            name = f"{relation_cls.__tableschema__}.{relation_cls.__tablename__}"
-            self._get_event(name).set()
 
 ## ## Consider Supplying a "Base" at each level of the database via __init__.py file
 ## class InjectionManagerFactory():
@@ -116,3 +50,74 @@ class EventInjectionManager:
 ##     @classmethod
 ##     def MACHINE_LEARNING(cls):
 ##         return InjectionManager(MachineLearningBase)
+
+
+## ## This is functional, but we lose atomicity per replay due to many sessions.
+
+## class EventInjectionManager:
+##     def __init__(self, base, session_factory):
+##         """
+##         Initialize the EventInjectionManager.
+##         :param base: SQLAlchemy Base, providing metadata and injectable models.
+##         """
+##         self.base = base
+##         self.metadata = base.metadata
+##         self.events = {}  # Dictionary to track events for each table
+##         self.session_factory = session_factory
+## 
+##     def _get_event(self, table_name):
+##         """
+##         Retrieve or create an asyncio.Event for a specific table.
+##         :param table_name: Fully qualified table name (e.g., schema.table).
+##         :return: asyncio.Event instance.
+##         """
+##         if table_name not in self.events:
+##             self.events[table_name] = Event()
+##         return self.events[table_name]
+## 
+##     async def inject(self, replay):
+##         """
+##         Perform the injection process using Event-based synchronization.
+##         :param replay: Parsed replay object to inject.
+##         :param session: Database session supporting flush, commit, and rollback.
+##         """
+##         tasks = []
+##         for name, relation in self.metadata.tables.items():
+##             relation_cls = self.base.injectable.get(name)
+## 
+##             if relation_cls and issubclass(relation_cls, Injectable):
+##                 # Define dependencies from the class relationships
+##                 dependencies = []
+##                 for dependency in relation.foreign_key_constraints:
+##                     fkey = f"{dependency.referred_table.schema}.{dependency.referred_table.name}"
+##                     dependencies.append(fkey)
+## 
+##                 # Inject the current relation
+##                 tasks.append(self._inject_relation(relation_cls, replay, dependencies))
+## 
+##         # Run all tasks concurrently
+##         await gather(*tasks)
+## 
+##     async def _inject_relation(self, relation_cls, replay, dependencies):
+##         """
+##         Inject a single relation, waiting for dependencies to complete.
+##         :param relation_cls: The model class to process.
+##         :param replay: Parsed replay object.
+##         :param session: Database session.
+##         :param dependencies: List of dependent table names.
+##         """
+##         for dep in dependencies:
+##             await self._get_event(dep).wait()  # Wait for dependencies to complete
+## 
+##         async with self.session_factory() as session:
+##             try:
+##                 # Process the current relation
+##                 await relation_cls.process(replay, session)
+##                 await session.flush()  # Flush after processing
+##             except Exception as e:
+##                 await session.rollback()
+##                 print(f"Error processing {relation_cls.__tablename__}: {e}")
+##             finally:
+##                 # Signal that this relation is complete
+##                 name = f"{relation_cls.__tableschema__}.{relation_cls.__tablename__}"
+##                 self._get_event(name).set()

--- a/database/warehouse/datapack/ability.py
+++ b/database/warehouse/datapack/ability.py
@@ -58,7 +58,6 @@ class ability(Injectable, Base):
         except Exception as e:
             await session.rollback()
             print(f"Unexpected error: {e}")
-            breakpoint()
             # Gracefully handle all other exceptions
 
     @classmethod
@@ -71,7 +70,7 @@ class ability(Injectable, Base):
     async def process_dependancies(cls, ability, replay, session):
         unit = ability.build_unit
         if not unit:
-            return { "unit_type_id" : None}
+            return { "unit_type_id" : None }
 
         statement = select(unit_type).where(
                 and_(unit_type.release_string == replay.release_string, unit_type.id == unit.id))
@@ -79,7 +78,7 @@ class ability(Injectable, Base):
         unit      = result.scalar()
 
         if not unit:
-            return { "unit_type_id" : None}
+            return { "unit_type_id" : None }
 
         return { "unit_type_id" : unit.primary_id }
 

--- a/database/warehouse/datapack/unit_type.py
+++ b/database/warehouse/datapack/unit_type.py
@@ -73,7 +73,7 @@ class unit_type(Base, Injectable):
     def get_unique(cls, replay):
         units = {}
         for _, unit in replay.datapack.units.items():
-            if unit.id not in units.keys():
+            if unit.race != 'Neutral':
                 units[unit.id] = unit
         return units
 

--- a/database/warehouse/replay/map.py
+++ b/database/warehouse/replay/map.py
@@ -1,10 +1,16 @@
 from sqlalchemy import Column, Integer, Text, LargeBinary
+from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy.future import select
 from sqlalchemy.orm import relationship
 
+from asyncio import Lock
+
+from database.inject import Injectable
 from database.base import Base
 
 
-class map(Base):
+class map(Injectable, Base):
+    _lock = Lock()
     __tablename__ = "map"
     __table_args__ = {"schema": "replay"}
 
@@ -16,6 +22,60 @@ class map(Base):
     author = Column(Text)
     description = Column(Text)
     website = Column(Text)
-    minimap = Column(LargeBinary)
+    minimap = Column(LargeBinary) ## Store elsewhere?
 
     replays = relationship("info", back_populates="map")
+
+    @classmethod
+    @property
+    def __tableschema__(self):
+        return "replay"
+
+    @classmethod
+    async def process(cls, replay, session):
+        async with cls._lock:
+            try:
+                if await cls.process_existence(replay.map.filehash, session):
+                    return
+
+                data = cls.get_data(replay.map)
+                breakpoint()
+                session.add(cls(**data))
+
+            except IntegrityError as e:
+                await session.rollback()
+                print(f"IntegrityError: {e.orig}")
+                # Handle specific cases like unique constraint violations
+            except OperationalError as e:
+                await session.rollback()
+                print(f"OperationalError: {e.orig}")
+                # Handle deadlocks or connection issues
+            except Exception as e:
+                await session.rollback()
+                print(f"Unexpected error: {e}")
+                # Gracefully handle all other exceptions
+
+    @classmethod
+    async def process_existence(cls, filehash, session):
+        statement = select(cls).where(cls.filehash == filehash)
+        result = await session.execute(statement)
+        breakpoint()
+        return result.scalar()
+
+    @classmethod
+    def get_data(cls, obj):
+        parameters = {}
+        for variable, value in vars(obj).items():
+            if variable in cls.columns:
+                parameters[variable] = value
+        return parameters
+
+    columns = \
+        { "filename"
+        , "filehash"
+        , "name"
+        , "author"
+        , "description"
+        , "website"
+        , "minimap"
+        }


### PR DESCRIPTION
Reverted to InjectionManager to preserve atomicity across all relations within a single transaction. The EventInjectionManager has been abandoned due to challenges with ensuring consistent rollbacks across multiple sessions. This change ensures safer and more predictable database operations.