### PR TITLE
feature injection manager

### DIFF
--- a/database/warehouse/datapack/unit_type.py
+++ b/database/warehouse/datapack/unit_type.py
@@ -54,8 +54,7 @@ class unit_type(Base, Injectable):
     def get_unique(cls, replay):
         units = {}
         for _, unit in replay.datapack.units.items():
-            if unit.race != 'Neutral':
-                units[unit.id] = unit
+            units[unit.id] = unit
         return units
 
     columns = \

--- a/database/warehouse/events/unit_died_event.py
+++ b/database/warehouse/events/unit_died_event.py
@@ -1,13 +1,15 @@
-from sqlalchemy import Column, Integer, Text, ForeignKey
+from sqlalchemy import Column, Integer, Text, ForeignKey, and_
+from sqlalchemy.future import select
 from sqlalchemy.orm import relationship
 
-from database.base import Base
+from collections import defaultdict
 
 from database.warehouse.replay.info import info
-from database.warehouse.replay.player import player
-from database.warehouse.datapack.unit_type import unit_type
+from database.warehouse.replay.object import object
+from database.inject import Injectable
+from database.base import Base
 
-class unit_died_event(Base):
+class unit_died_event(Injectable, Base):
     __tablename__ = "unit_died_event"
     __table_args__ = {"schema": "events"}
 
@@ -16,10 +18,6 @@ class unit_died_event(Base):
     frame = Column(Integer)
     second = Column(Integer)
     name = Column(Text)
-    unit_id_index = Column(Integer)
-    unit_id_recycle = Column(Integer)
-    unit_id = Column(Integer)
-    killer_pid = Column(Integer)
     x = Column(Integer)
     y = Column(Integer)
 
@@ -38,6 +36,59 @@ class unit_died_event(Base):
     info_id = Column(Integer, ForeignKey("replay.info.primary_id"))
     info = relationship("info", back_populates="unit_died_events")
 
-    player_id = Column(Integer, ForeignKey("replay.player.primary_id"))
-    killing_player = relationship("player", back_populates="unit_died_events")
+    @classmethod
+    @property
+    def __tableschema__(self):
+        return "events"
+
+    @classmethod
+    async def process(cls, replay, session):
+        events = replay.events_dictionary['UnitDiedEvent']
+
+        _events = []
+        for event in events:
+            data = cls.get_data(event)
+            parents = await cls.process_dependancies(event, replay, session)
+
+            _events.append(cls(**data, **parents))
+
+        session.add_all(_events)
+
+    @classmethod
+    async def process_dependancies(cls, event, replay, session):
+        _info, _unit, _killing_unit = replay.filehash, event.unit_id, event.killing_unit_id
+        parents = defaultdict(lambda:None)
+
+        info_statement = select(info).where(info.filehash == _info)
+        info_result = await session.execute(info_statement)
+        _info = info_result.scalar()
+        parents['info_id'] = _info.primary_id
+
+        unit_statement = select(object).where(
+                and_(object.info_id == _info.primary_id, object.id == _unit))
+        unit_result = await session.execute(unit_statement)
+        _unit = unit_result.scalar()
+        parents['unit_id'] = _unit.primary_id
+
+        # Not all units have a killer.
+        if not _killing_unit:
+            return parents
+
+        killing_unit_statement = select(object).where(
+                and_(object.info_id == _info.primary_id, object.id == _killing_unit))
+        killing_unit_result = await session.execute(killing_unit_statement)
+        _killing_unit = killing_unit_result.scalar()
+
+        parents['killing_unit_id'] = _killing_unit.primary_id
+
+        return parents
+
+
+    columns = \
+        { "frame"
+        , "second"
+        , "name"
+        , "x"
+        , "y"
+        }
 

--- a/database/warehouse/replay/object.py
+++ b/database/warehouse/replay/object.py
@@ -1,14 +1,18 @@
-from sqlalchemy import Column, Integer, Text, LargeBinary, ForeignKey
+from sqlalchemy import Column, Integer, Text, LargeBinary, ForeignKey, and_
+from sqlalchemy.future import select
 from sqlalchemy.orm import relationship
 
-from database.base import Base
+from collections import defaultdict
 
 from database.warehouse.replay.info import info
 from database.warehouse.replay.player import player
+from database.warehouse.replay.user import user
 from database.warehouse.datapack.unit_type import unit_type
+from database.inject import Injectable
+from database.base import Base
 
 
-class object(Base):
+class object(Injectable, Base):
     __tablename__ = "object"
     __table_args__ = {"schema": "replay"}
 
@@ -29,14 +33,6 @@ class object(Base):
         primaryjoin="object.owner_id==player.primary_id",
         back_populates="owned_objects",)
 
-    killing_player_id = Column(Integer, ForeignKey('replay.player.primary_id'))
-    killing_player = relationship(
-        "player",
-        primaryjoin='object.killing_player_id==player.primary_id',
-        back_populates='killed_objects')
-
-    killing_unit_id = Column(Integer, ForeignKey("replay.object.primary_id"), nullable=True)
-    killing_unit = relationship("object", remote_side=[primary_id], backref="killed_units")
 
     unit_type_id = Column(Integer, ForeignKey("datapack.unit_type.primary_id"))
     unit_type = relationship(
@@ -61,3 +57,57 @@ class object(Base):
     @property
     def __tableschema__(self):
         return "replay"
+
+    @classmethod
+    async def process(cls, replay, session):
+        _objects = []
+        for _, obj in replay.objects.items():
+            data = cls.get_data(obj)
+            parents = await cls.process_dependancies(obj, replay, session)
+            if not parents:
+                continue
+
+            _objects.append(cls(**data, **parents))
+
+        session.add_all(_objects)
+        breakpoint()
+
+
+    @classmethod
+    async def process_dependancies(cls, obj, replay, session):
+        _unit, _info, _player = obj._type_class, replay.filehash, obj.owner
+        if not (_unit and _info and _player and _unit.race != "Neutral"):
+            return None
+
+        unit_statement = select(unit_type).where(
+                and_(unit_type.release_string == replay.release_string, unit_type.id == _unit.id))
+        unit_result = await session.execute(unit_statement)
+        _unit = unit_result.scalar()
+
+        info_statement = select(info).where(info.filehash == _info)
+        info_result = await session.execute(info_statement)
+        _info = info_result.scalar()
+
+        user_statement = select(user).where(user.uid == _player.detail_data.get("bnet").get("uid"))
+        user_result = await session.execute(user_statement)
+        _user = user_result.scalar()
+
+        player_statement = select(player).where(
+                and_(player.info_id == _info.primary_id, player.user_id == _user.primary_id))
+        player_result = await session.execute(player_statement)
+        _player = player_result.scalar()
+
+        parents = defaultdict(lambda:None)
+        parents["unit_type_id"] = _unit.primary_id
+        parents["info_id"] = _info.primary_id
+        parents["owner_id"] = _player.primary_id
+
+        return parents
+
+    columns = \
+        { "id"
+        , "started_at"
+        , "finished_at"
+        , "died_at"
+        , "name"
+        }

--- a/database/warehouse/replay/player.py
+++ b/database/warehouse/replay/player.py
@@ -41,7 +41,6 @@ class player(Injectable, Base):
     player_stats_events = relationship("player_stats_event", back_populates="player")
     player_leave_events = relationship("player_leave_event", back_populates="player")
     unit_born_events = relationship("unit_born_event", back_populates="unit_controller")
-    unit_died_events = relationship("unit_died_event", back_populates="killing_player")
     upgrade_complete_events = relationship("upgrade_complete_event", back_populates="player")
 
     @classmethod
@@ -59,8 +58,6 @@ class player(Injectable, Base):
             players.append(cls(**data, **parents))
 
         session.add_all(players)
-
-
 
     @classmethod
     async def process_dependancies(cls, obj, replay, session):

--- a/database/warehouse/replay/player.py
+++ b/database/warehouse/replay/player.py
@@ -35,7 +35,6 @@ class player(Injectable, Base):
     user = relationship("user", back_populates="players")
 
     owned_objects = relationship( "object", primaryjoin="object.owner_id==player.primary_id", back_populates="owner")
-    killed_objects = relationship("object", primaryjoin="object.killing_player_id==player.primary_id", back_populates="killing_player")
 
     basic_command_events = relationship("basic_command_event", back_populates="player")
     chat_events = relationship("chat_event", back_populates="player")
@@ -69,12 +68,11 @@ class player(Injectable, Base):
         parents = defaultdict(lambda:None)
 
         user_statement = select(user).where(user.uid == _uid)
-        info_statement = select(info).where(info.filehash == _filehash)
-
         user_result = await session.execute(user_statement)
-        info_result = await session.execute(info_statement)
-
         _user = user_result.scalar()
+
+        info_statement = select(info).where(info.filehash == _filehash)
+        info_result = await session.execute(info_statement)
         _info = info_result.scalar()
 
         parents['user_id'] = _user.primary_id


### PR DESCRIPTION
Implement Injectable on unit_died_event -> Normalize table w.r.t players as ownership of killing and killed unit belong to object table. Handle missing ownership in object ORM and 'suicide' on unit_died_event (no killing unit)